### PR TITLE
Removed check validating whether the attached instance exists when se…

### DIFF
--- a/nova/api/ec2/cloud.py
+++ b/nova/api/ec2/cloud.py
@@ -817,9 +817,6 @@ class CloudController(object):
 
         if volume.get('instance_uuid', None):
             instance_uuid = volume['instance_uuid']
-            # Make sure instance exists
-            objects.Instance.get_by_uuid(context.elevated(), instance_uuid)
-
             instance_ec2_id = ec2utils.id_to_ec2_inst_id(instance_uuid)
 
         v = {}


### PR DESCRIPTION
…rializing volume

This check causes boto's get_all_volumes() call to fail in its entirety should even one volume happen to be out of sync/have stale attachment information.

I tried to trace the origin of this check and it looks like the check was mainly an artefact of refactoring, and not put in to specifically guard against some condition. Therefore, removing it altogether seems like the best option. The one side-effect will be that state attachment information may be sent back to the client, but this is something that should probably be fixed at a different level.
